### PR TITLE
Bump WINVER 'cuz on default values some required fns are not defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,13 @@ if (HARFBUZZ_BUILD_ICU)
           -wd4267
           -wd4244)
     endif()
+    if(WIN32)
+    # Needed for MinGW (MSVC probably too) - set minimum windows version for locale fns.
+    target_compile_definitions(icucommon
+        PRIVATE
+        WINVER=0x0601
+        _WIN32_WINNT=0x601)
+    endif()
 endif()
 
 


### PR DESCRIPTION
Part of https://github.com/tangrams/tangram-es/pull/2272

There are some missing API errors when building tangram-es. I could add the updated `WINVER` as global define `add_definitions()` but then it collides with GLFW's `WINVER` override, thus producing compile warnings. The solution is to set it separately for icu and for tangram targets